### PR TITLE
Fix APDnsDatagram copyWithZone implementation

### DIFF
--- a/AdguardExtension/AdguardPro/SharedComponents/APDnsDatagram.m
+++ b/AdguardExtension/AdguardPro/SharedComponents/APDnsDatagram.m
@@ -97,7 +97,7 @@
     APDnsDatagram *obj = [APDnsDatagram new];
     
     obj.ID = self.ID;
-    obj.isRequest = obj.isRequest ;
+    obj.isRequest = self.isRequest;
     obj.isResponse = self.isResponse;
     obj.requests = [self.requests copyWithZone:zone];
     obj.responses = [self.responses copyWithZone:zone];


### PR DESCRIPTION
There seems to be an issue with `APDnsDatagram` `copyWithZone(_:)` implementation:

```objc
- (id)copyWithZone:(NSZone *)zone {
    
    APDnsDatagram *obj = [APDnsDatagram new];
    
    obj.ID = self.ID;
    obj.isRequest = obj.isRequest ; // <-- obj instead of self
    obj.isResponse = self.isResponse;
```

Classic mistake 😃