### PR TITLE
Add alternative DNS IPs

### DIFF
--- a/AdguardExtension/AdguardApp/providers.json
+++ b/AdguardExtension/AdguardApp/providers.json
@@ -51,7 +51,9 @@
           "name": "Google DNS",
           "upstreams": [
             "8.8.8.8",
-            "8.8.4.4"
+            "8.8.4.4",
+            "2001:4860:4860::8888",
+            "2001:4860:4860::8844"
             ]
         },
         {
@@ -94,7 +96,9 @@
           "name": "Cloudflare",
           "upstreams":[
             "1.1.1.1",
-            "1.0.0.1"
+            "1.0.0.1",
+            "2606:4700:4700::1111",
+            "2606:4700:4700::1001"
           ]
         },
         {
@@ -103,6 +107,8 @@
           "id": "cloudflare",
           "name": "cloudflare",
           "upstreams":[
+            "https://1.1.1.1/dns-query",
+            "https://1.0.0.1/dns-query",
             "https://cloudflare-dns.com/dns-query"
           ]
         },
@@ -112,7 +118,8 @@
           "id": "cloudflare-dot",
           "name": "cloudflare-dot",
           "upstreams":[
-            "tls://1.1.1.1"
+            "tls://1.1.1.1",
+            "tls://1.0.0.1"
           ]
         }
       ]
@@ -205,7 +212,9 @@
           "name": "Quad9",
           "upstreams":[
             "9.9.9.9",
-            "149.112.112.112"
+            "149.112.112.112",
+            "2620:fe::fe",
+            "2620:fe::9"
           ]
         },
         {
@@ -223,6 +232,7 @@
           "id": "quad9-doh-filter-pri",
           "name": "quad9-doh-ipv4-filter-pri",
           "upstreams":[
+            "https://149.112.112.9/dns-query",
             "https://dns9.quad9.net/dns-query"
           ]
         }


### PR DESCRIPTION
Resolves #1402 

Actually resolves most of #1402, doesn't add Cloudflare Resolver for Firefox. Keeping Cloudflare Resolver and adding Cloudflare Resolver for Firefox would be confusing.

This pull request does:

- Add IPv6 IPs (because why not?) but with lower priority than IPv4 IPs since usually IPv4 peerings are better.
- Use plain IPs wherever possible rather than relying on the default DNS resolver.

Resources:
- https://developers.google.com/speed/public-dns/docs/using#google_public_dns_ip_addresses
- https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1
- https://developers.cloudflare.com/1.1.1.1/dns-over-https/cloudflared-proxy/ (Ctrl + F for `https://1.1.1.1/dns-query`)
- https://developers.cloudflare.com/1.1.1.1/dns-over-tls
- https://www.quad9.net/doh-quad9-dns-servers/
- https://www.quad9.net/faq/

Notes: For Quad9 DoH ( https://www.quad9.net/doh-quad9-dns-servers/ ) I'm adding just one alternative address because how their addresses are organized is complex:

`https://dns9.quad9.net/dns-query` is what Adguard uses, named "Secure". There's also `https://dns.quad9.net/dns-query` which is just the "recommended" but the documentation says it maps to "Secure". `149.112.112.9` is the only address documented as the equivalent of `https://dns9.quad9.net/dns-query` but not `https://dns.quad9.net/dns-query`.